### PR TITLE
Move single use packages to live in this repo

### DIFF
--- a/bin/find-entry.js
+++ b/bin/find-entry.js
@@ -4,9 +4,9 @@
 
 require("dotenv").config();
 
-const EntryWatcher = require("@lukekarrys/entry-watcher");
 const config = require("getconfig");
 const yargs = require("yargs");
+const EntryWatcher = require("../watchers/entry-watcher");
 
 const onSave = require("../lib/saveEntry");
 const createLogger = require("../lib/logger");

--- a/package-lock.json
+++ b/package-lock.json
@@ -817,6 +817,12 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "bucker": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bucker/-/bucker-1.1.1.tgz",
@@ -1297,6 +1303,12 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
+    "diff": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
+    },
     "directmail": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/directmail/-/directmail-0.1.8.tgz",
@@ -1336,6 +1348,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2024,6 +2042,12 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2296,6 +2320,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -2809,6 +2839,56 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
       "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
     },
+    "mocha": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "4.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "he": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+          "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        }
+      }
+    },
     "module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
@@ -3100,6 +3180,12 @@
         "error-ex": "^1.2.0"
       }
     },
+    "parse-ms": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-1.0.1.tgz",
+      "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
+      "dev": true
+    },
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
@@ -3274,6 +3360,12 @@
           }
         }
       }
+    },
+    "plur": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
+      "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
+      "dev": true
     },
     "pluralize": {
       "version": "7.0.0",
@@ -3529,6 +3621,17 @@
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true
     },
+    "pretty-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-2.1.0.tgz",
+      "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -3662,6 +3765,12 @@
         }
       }
     },
+    "re-emitter": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.4.tgz",
+      "integrity": "sha512-C0SIXdXDSus2yqqvV7qifnb4NoWP7mEBXJq3axci301mXHCZb8Djwm4hrEZo4UeXRaEnfjH98uQ8EBppk2oNWA==",
+      "dev": true
+    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -3714,6 +3823,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.85.0",
@@ -4092,6 +4207,15 @@
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -4260,6 +4384,65 @@
         "string-width": "^2.1.1"
       }
     },
+    "tap-out": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tap-out/-/tap-out-1.4.2.tgz",
+      "integrity": "sha1-yQfsG/lAURHQiCY+kvVgi4jLs3o=",
+      "dev": true,
+      "requires": {
+        "re-emitter": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "split": "^1.0.0",
+        "trim": "0.0.1"
+      }
+    },
+    "tap-spec": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-4.1.2.tgz",
+      "integrity": "sha512-CmZP7vp9Jk7fND0nvdjIzjGMZnBDx1jVG7T9x6i2GZb/ejIODGz7OSsWFfwwuEcY9yHWtpD/mdLverla0M8EWA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.0.0",
+        "duplexer": "^0.1.1",
+        "figures": "^1.4.0",
+        "lodash": "^3.6.0",
+        "pretty-ms": "^2.1.0",
+        "repeat-string": "^1.5.2",
+        "tap-out": "^1.4.1",
+        "through2": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
+      }
+    },
     "tape": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
@@ -4309,6 +4492,48 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "thunkify": {
       "version": "2.1.2",
@@ -4369,6 +4594,12 @@
           "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
     },
     "tryit": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,38 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@lukekarrys/entry-watcher": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@lukekarrys/entry-watcher/-/entry-watcher-5.1.5.tgz",
-      "integrity": "sha512-fZqWwWJS5zGwDSCC+kmxPL2rQFodPcDEiDag3+w3ina3K49SOVMhSEMLUz9dwuaI3dj9/+teHIN7giDm4IMO4g==",
-      "requires": {
-        "async": "^2.3.0",
-        "bracket-data": "^4.5.15",
-        "bracket-finder": "^3.0.1",
-        "bucker": "^1.1.1",
-        "lodash": "^4.17.4",
-        "moment": "^2.21.0",
-        "twit": "^2.2.5"
-      }
-    },
     "@lukekarrys/eslint-config": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@lukekarrys/eslint-config/-/eslint-config-6.0.4.tgz",
       "integrity": "sha512-hxlFzyySQ3ObJ7Oy26fgOptF399M8alFgUZE1hYJqJzd2FN8v8JWPGpvOiapEsxj5/PZArA0rhVxT4sQrKEo0g==",
       "dev": true
-    },
-    "@lukekarrys/score-watcher": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@lukekarrys/score-watcher/-/score-watcher-5.2.4.tgz",
-      "integrity": "sha512-sY24p5CyaDe+0zSl9Kql/STbCH+3Tr2Qwb6LRX26fmGLgZ0npwLudHrnOT4Pa2unTEnHxEK4+bC/bOV5Skpw3Q==",
-      "requires": {
-        "async": "^2.1.4",
-        "bracket-data": "^4.4.0",
-        "bracket-updater": "^3.4.1",
-        "bucker": "^1.1.1",
-        "lodash": "^4.17.2",
-        "scores": "^3.9.0"
-      }
     },
     "@opencensus/core": {
       "version": "0.0.9",
@@ -758,18 +731,6 @@
       "integrity": "sha512-q/AsmvfvJM/8wVWj3m16jD8yAjMIppvM86Fl+ua5040U627FxVbxz1OpXEMDDxO894dEBcTLLZtL9ESsQzbtcw==",
       "requires": {
         "lodash.merge": "^4.5.1"
-      }
-    },
-    "bracket-finder": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bracket-finder/-/bracket-finder-3.0.1.tgz",
-      "integrity": "sha1-L/4ufJ306L6c4SgiFBJGr/MC/wM=",
-      "requires": {
-        "async": "^2.0.1",
-        "bracket-data": "^4.2.3",
-        "bracket-validator": "^3.0.3",
-        "lodash": "^4.14.2",
-        "simple-realurl": "^1.1.1"
       }
     },
     "bracket-generator": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
     "url": "https://bitbucket.org/lukekarrys/data/issues"
   },
   "dependencies": {
-    "@lukekarrys/entry-watcher": "^5.1.5",
-    "@lukekarrys/score-watcher": "^5.2.4",
     "async": "^2.4.1",
     "bracket-data": "^4.6.10",
     "bracket-updater": "^3.4.7",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,16 @@
     "async": "^2.4.1",
     "bracket-data": "^4.6.10",
     "bracket-updater": "^3.4.7",
+    "bracket-validator": "^3.1.1",
     "bucker": "^1.1.1",
     "dotenv": "^4.0.0",
     "getconfig": "^4.4.1",
     "lodash": "^4.17.4",
+    "moment": "^2.21.0",
     "pg": "^8.5.1",
     "scores": "^3.9.4",
+    "simple-realurl": "^1.1.2",
+    "twit": "^2.2.5",
     "yargs": "^10.0.3"
   },
   "devDependencies": {
@@ -35,9 +39,11 @@
     "eslint-plugin-promise": "^3.5.0",
     "git-validate": "^2.2.2",
     "json": "^10.0.0",
+    "mocha": "^4.0.1",
     "ms": "^2.0.0",
     "pm2": "^4.5.5",
     "prettier": "^2.2.1",
+    "tap-spec": "^4.1.1",
     "tape": "^4.6.3"
   },
   "engines": {
@@ -63,20 +69,23 @@
     "url": "git://bitbucket.org/lukekarrys/data.git"
   },
   "scripts": {
-    "reset-db": "./bin/db.sh",
-    "reset-db:test": "npm run reset-db -- bracketclub-test test",
-    "reset-db:dev": "npm run reset-db -- bracketclub development",
     "deploy": "./bin/linode.sh",
     "dump": "./bin/dump.js",
     "dump:prod-to-dev": "NODE_ENV=production npm run dump && npm run reset-db:dev && npm run dump",
+    "find-entry": "./bin/find-entry.js",
     "heroku:psql": "heroku pg:psql postgresql-solid-92636 --app bracketclub",
     "heroku:web": "open https://data.heroku.com/datastore/768c0b8c-6f86-451a-8cac-ddc7ec2940b5",
     "insert-by-team": "./bin/insert-by-team.js",
-    "find-entry": "./bin/find-entry.js",
     "integration": "NODE_ENV=test ./bin/integration.sh",
     "lint": "prettier -l . && eslint .",
     "logs:clean": "rm -rf logs",
+    "reset-db": "./bin/db.sh",
+    "reset-db:dev": "npm run reset-db -- bracketclub development",
+    "reset-db:test": "npm run reset-db -- bracketclub-test test",
     "start": "./bin/pm2.sh",
-    "test": "NODE_ENV=test tape test/*.js"
+    "test": "NODE_ENV=test tape test/*.js && npm run test:entries && npm run test:scores && npm run test:finder",
+    "test:entries": "mocha -c -u bdd -R spec --timeout 15000 watchers/entry-watcher/test/*.js",
+    "test:finder": "mocha -c -u bdd -R spec --timeout 10000 watchers/bracket-finder/test/*.js",
+    "test:scores": "tape watchers/score-watcher/test/test.js | tap-spec"
   }
 }

--- a/watchers/bracket-finder/README.md
+++ b/watchers/bracket-finder/README.md
@@ -1,0 +1,64 @@
+# bracket-finder
+
+Find a tournament bracket in a tweet (or any data object).
+
+[![NPM](https://nodei.co/npm/bracket-finder.png)](https://nodei.co/npm/bracket-finder/)
+
+[![Build Status](https://travis-ci.org/bracketclub/bracket-finder.png?branch=master)](https://travis-ci.org/bracketclub/bracket-finder)
+
+## Why is this useful?
+
+For [bracket.club](https://bracket.club), users enter by tweeting a link to their bracket. This module can parse a tweet and determine if it contains a valid bracket. It also has a lower level method `find` that can be used to find a tweet in a more generic data object.
+
+## How does it determine if a bracket is found?
+
+1. It will check whether any links are from `options.domain`
+2. If that fails, it will check whether any of the tags match a tag from `options.tags`
+
+If both of those fail, it will fire the callback with an error (unless `forceMatch` contains either `tags` or `domain`). After that it will look for a bracket in:
+
+1. Any of the urls that match the domain
+2. Any of the tags
+3. Any chunks of text (split by spaces)
+
+If any of these find a bracket, it will be [validated](https://github.com/bracketclub/bracket-validator) the result will be passed to the callback. If no bracket is still found, any URLs will be followed using [simple-realurl](https://github.com/lukekarrys/simple-node-realurl) and checked again to see if they match the domain and contain a bracket.
+
+## API / Usage
+
+Make a new `bracket-finder` object with an options object (the year and sport options are required and passed directly to [`bracket-data`](https://github.com/bracketclub/bracket-data#which-sports-does-it-have)):
+
+```js
+var BracketFinder = require("bracket-finder");
+var finder = new BracketFinder({
+  year: "2013",
+  sport: "ncaam",
+  domain: "bracket.club",
+  tags: ["tybrtk"],
+});
+finder.tweet(tweet, function (err, bracket) {
+  if (err) return; // No bracket found
+  // Do something with bracket
+});
+```
+
+### options
+
+- `sport`: The sport you are validating. See [`bracket-data`](https://github.com/bracketclub/bracket-data#api) for more info.
+- `year`: The year you are validating. See [`bracket-data`](https://github.com/bracketclub/bracket-data#api) for more info.
+- `domain`: (String, default: '') The domain that a bracket tweet or data object might contain
+- `tags`: (Array, default: []) An array of (hash)tags (but without the `#`) that a bracket tweet or data object might contain
+- `forceMatch`: (Array, default: ['tags']) Indicates which properties must be specified in the data. Can contain `tags`, `domain`, both or neither
+- `allowCrossDomain`: (Boolean, default: depends on environment) By default if you run this in a browser, cross domain urls will not be requested. If you would like to change this, set the option to `true`. When running in node, it defaults to true.
+
+### methods
+
+- `tweet(tweetObject, cb)`: tweetObject should in the format of a tweet from Twitter's API
+- `find(dataObject, cb)`: dataObject should have the following:
+
+```js
+{
+    urls: ['https://bracket.club/X'],
+    tags: ['bracketclub']
+    text: 'This is the text!'
+}
+```

--- a/watchers/bracket-finder/index.js
+++ b/watchers/bracket-finder/index.js
@@ -1,0 +1,175 @@
+"use strict";
+
+const parseUrl = require("url").parse;
+const async = require("async");
+const realurl = require("simple-realurl");
+const BracketValidator = require("bracket-validator");
+const bracketData = require("bracket-data");
+const _map = require("lodash/map");
+const _find = require("lodash/find");
+const _defaults = require("lodash/defaults");
+const _filter = require("lodash/filter");
+const _without = require("lodash/without");
+const _bind = require("lodash/bind");
+const _compact = require("lodash/compact");
+const _intersection = require("lodash/intersection");
+const _includes = require("lodash/includes");
+const _partial = require("lodash/partial");
+
+class Finder {
+  constructor(options) {
+    _defaults(options, {
+      domain: "",
+      tags: [],
+      forceMatch: ["tags"],
+      // By default dont follow cross domain links if we are in a browser
+      followCrossDomain: typeof window === "undefined",
+    });
+
+    this.domain = options.domain;
+    this.tags = options.tags;
+    this.forceMatch = options.forceMatch || [];
+    this.followCrossDomain = options.followCrossDomain;
+
+    // Create regexes and validator for later use
+    const bracketRegex = bracketData({
+      sport: options.sport,
+      year: options.year,
+    }).regex;
+
+    const fullBracketRegex = new RegExp(`^${bracketRegex.source}$`);
+
+    const validator = new BracketValidator({
+      sport: options.sport,
+      year: options.year,
+      testOnly: true,
+      allowEmpty: false,
+    });
+
+    // Create helper functions
+    this.validate = (bracket, cb) => {
+      const validated = validator.validate(bracket);
+      cb(
+        validated instanceof Error ? validated : null,
+        validated instanceof Error ? null : validated
+      );
+    };
+
+    this.findBracket = (from) =>
+      _find(from, (item) => fullBracketRegex.test(item));
+
+    this.domainUrls = _partial(
+      (domain, url) => url.toLowerCase().indexOf(domain.toLowerCase()) > -1,
+      this.domain
+    );
+
+    this.bracketUrls = (url) => {
+      const matches = url.match(bracketRegex);
+      return matches && matches.length > 0 ? matches[0] : matches;
+    };
+
+    this.canGetUrl = _partial((followCrossDomain, url) => {
+      if (typeof window === "undefined") {
+        return true;
+      }
+      const parsedUrl = parseUrl(url);
+      const { location } = window;
+      return (
+        (location.protocol === parsedUrl.protocol &&
+          location.host === parsedUrl.host) ||
+        followCrossDomain
+      );
+    }, this.followCrossDomain);
+  }
+  tweet(tweet, cb) {
+    _defaults(tweet, { text: "", entities: {} });
+    this.find(
+      {
+        urls: _map(tweet.entities.urls, "expanded_url"),
+        tags: _map(tweet.entities.hashtags, "text"),
+        text: tweet.text.split(" "),
+      },
+      cb
+    );
+  }
+
+  find(data, cb) {
+    const self = this;
+    const appUrls = _filter(data.urls, this.domainUrls);
+
+    if (
+      _includes(this.forceMatch, "tags") &&
+      _intersection(this.tags, data.tags).length === 0
+    ) {
+      cb(new Error("Data does not match tags"));
+      return;
+    }
+
+    if (_includes(this.forceMatch, "domain") && appUrls.length === 0) {
+      cb(new Error("Data does not match domain"));
+      return;
+    }
+
+    const urlMatches = _compact(_map(appUrls, this.bracketUrls));
+    const dataTags = _without(data.tags, this.tags);
+    const textChunks = data.text;
+
+    async.waterfall(
+      [
+        (_cb) => {
+          // Most common scenario will be a url with a hash on it
+          // Then test for a valid hashtag
+          // Also test for a chunk of text that looks good
+          _cb(
+            null,
+            self.findBracket(urlMatches) ||
+              self.findBracket(dataTags) ||
+              self.findBracket(textChunks)
+          );
+        },
+        (bracket, _cb) => {
+          if (bracket) {
+            _cb(null, bracket);
+            return;
+          }
+
+          // Last, check other urls to see if the are matching urls
+          const otherUrls = _filter(
+            _without(data.urls, appUrls),
+            self.canGetUrl
+          );
+          async.concat(
+            otherUrls,
+            _bind(realurl.get, realurl),
+            (err, longUrls) => {
+              if (err) {
+                _cb(err, null);
+                return;
+              }
+
+              const longAppUrls = _filter(longUrls, self.domainUrls);
+              const longUrlMatches = _compact(
+                _map(longAppUrls, self.bracketUrls)
+              );
+              const longBracket = self.findBracket(longUrlMatches);
+
+              _cb(
+                longBracket ? null : new Error("No bracket in tweet"),
+                longBracket || null
+              );
+            }
+          );
+        },
+      ],
+      (err, res) => {
+        if (err) {
+          cb(err, null);
+          return;
+        }
+        self.validate(res, cb);
+      }
+    );
+  }
+}
+
+module.exports = Finder;

--- a/watchers/bracket-finder/test/test.js
+++ b/watchers/bracket-finder/test/test.js
@@ -1,0 +1,251 @@
+/* eslint-disable camelcase */
+/* eslint-env mocha */
+
+"use strict";
+
+const assert = require("assert");
+const bd = require("bracket-data");
+const BracketGenerator = require("bracket-generator");
+
+const APP_NAME = "lukekarrys.com";
+const APP_HASHTAGS = ["sometaggg"];
+const _cloneDeep = function (obj) {
+  return JSON.parse(JSON.stringify(obj));
+};
+const year = "2013";
+const sport = "ncaam";
+const BracketFinder = require("../index");
+
+const bf = new BracketFinder({
+  domain: APP_NAME,
+  tags: APP_HASHTAGS,
+  year,
+  sport,
+});
+
+const emptyBracket = bd({
+  year,
+  sport,
+}).constants.EMPTY;
+
+const generatedBracket = new BracketGenerator({
+  year,
+  sport,
+  winners: "lower",
+});
+const bracket = generatedBracket.generate();
+
+const fullTweet = {
+  text: `There is no important${bracket}text in this tweet`,
+  entities: {
+    urls: [
+      {
+        expanded_url: `http://lukecod.es/#${bracket}`,
+      },
+      {
+        expanded_url: "http://is.gd/WpcYwJ", // espn.com
+      },
+    ],
+    hashtags: [
+      {
+        text: APP_HASHTAGS[0],
+      },
+    ],
+  },
+};
+const goodUrl = { expanded_url: `http://${APP_NAME}/#${bracket}` };
+const goodText = `Some text of ${bracket} the tweet`;
+const goodHashtag = { text: bracket };
+
+// http://lukekarrys.com/#MW185463721432121W185463721432121S185463721432121E185463721432121FFMWSMW
+const shortenedUrl = "http://bit.ly/19ZYSVj";
+
+describe("Bracket Finder", () => {
+  it("should return a valid bracket from the url", (done) => {
+    const testTweet = _cloneDeep(fullTweet);
+    testTweet.entities.urls.push(goodUrl);
+    bf.tweet(testTweet, (err, res) => {
+      assert.equal(err, undefined);
+      assert.equal(bracket, res);
+      done();
+    });
+  });
+
+  it("should return a valid bracket from the text", (done) => {
+    const testTweet = _cloneDeep(fullTweet);
+    testTweet.text = goodText;
+    bf.tweet(testTweet, (err, res) => {
+      assert.equal(err, undefined);
+      assert.equal(bracket, res);
+      done();
+    });
+  });
+
+  it("should return a valid bracket from the hashtags", (done) => {
+    const testTweet = _cloneDeep(fullTweet);
+    testTweet.entities.hashtags.push(goodHashtag);
+    bf.tweet(testTweet, (err, res) => {
+      assert.equal(err, undefined);
+      assert.equal(bracket, res);
+      done();
+    });
+  });
+
+  it("should not return a bracket from a tweet that does not match tags", (done) => {
+    bf.tweet(
+      { text: "Test", entities: { urls: [], hashtags: [] } },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "Data does not match tags");
+        done();
+      }
+    );
+  });
+
+  it("should not return a bracket from a tweet that does not match domain", (done) => {
+    const bracketFinder = new BracketFinder({
+      domain: APP_NAME,
+      tags: APP_HASHTAGS,
+      year,
+      sport,
+      forceMatch: ["domain"],
+    });
+
+    bracketFinder.tweet(
+      { text: "Test", entities: { urls: [], hashtags: [] } },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "Data does not match domain");
+        done();
+      }
+    );
+  });
+
+  it("should not return a bracket from a tweet that does not match domain and tags when a tag is set", (done) => {
+    const bracketFinder = new BracketFinder({
+      domain: APP_NAME,
+      tags: APP_HASHTAGS,
+      year,
+      sport,
+      forceMatch: ["domain", "tags"],
+    });
+
+    bracketFinder.tweet(
+      {
+        text: "Test",
+        entities: { urls: [], hashtags: [{ text: "sometaggg" }] },
+      },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "Data does not match domain");
+        done();
+      }
+    );
+  });
+
+  it("should not return a bracket from a tweet that does not match domain and tags when a domain is set", (done) => {
+    const bracketFinder = new BracketFinder({
+      domain: APP_NAME,
+      tags: APP_HASHTAGS,
+      year,
+      sport,
+      forceMatch: ["domain", "tags"],
+    });
+
+    bracketFinder.tweet(
+      { text: "Test", entities: { urls: [goodUrl], hashtags: [] } },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "Data does not match tags");
+        done();
+      }
+    );
+  });
+
+  it("should not force domain or tags when option is an empty array", (done) => {
+    const bracketFinder = new BracketFinder({
+      domain: APP_NAME,
+      tags: APP_HASHTAGS,
+      year,
+      sport,
+      forceMatch: null,
+    });
+
+    bracketFinder.tweet(
+      { text: "Test", entities: { urls: [], hashtags: [] } },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "No bracket in tweet");
+        done();
+      }
+    );
+  });
+
+  it("should not return a bracket from a bad tweet", (done) => {
+    bf.tweet(
+      {
+        text: "Test",
+        entities: { urls: [], hashtags: [{ text: "sometaggg" }] },
+      },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "No bracket in tweet");
+        done();
+      }
+    );
+  });
+
+  it("should not a validate bracket if bracket is incomplete", (done) => {
+    bf.tweet(
+      {
+        text: emptyBracket,
+        entities: { urls: [], hashtags: [{ text: "sometaggg" }] },
+      },
+      (err, res) => {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "Bracket has unpicked matches");
+        done();
+      }
+    );
+  });
+
+  it.skip("should return a valid bracket from a shortened url (unless in a browser)", (done) => {
+    const bff = new BracketFinder({
+      domain: APP_NAME,
+      tags: APP_HASHTAGS,
+      year,
+      sport,
+    });
+    const testTweet = _cloneDeep(fullTweet);
+    testTweet.entities.urls.push({ expanded_url: shortenedUrl });
+    bff.tweet(testTweet, (err, res) => {
+      if (typeof window === "undefined") {
+        assert.equal(null, err);
+        assert.equal(bracket, res);
+        done();
+      } else {
+        assert.equal(null, res);
+        assert.equal(true, err instanceof Error);
+        assert.equal(err.message, "No bracket in tweet");
+        done();
+      }
+    });
+  });
+
+  it("should not return a bracket from a bad tweet", (done) => {
+    const testTweet = _cloneDeep(fullTweet);
+    bf.tweet(testTweet, (err, res) => {
+      assert.equal(null, res);
+      assert.equal(true, err instanceof Error);
+      assert.equal(err.message, "No bracket in tweet");
+      done();
+    });
+  });
+});

--- a/watchers/entries.js
+++ b/watchers/entries.js
@@ -2,8 +2,8 @@
 
 require("dotenv").config();
 
-const EntryWatcher = require("@lukekarrys/entry-watcher");
 const config = require("getconfig");
+const EntryWatcher = require("./entry-watcher");
 
 const initialBracket = require("../lib/initialBracket");
 const onSave = require("../lib/saveEntry");

--- a/watchers/entry-watcher/index.js
+++ b/watchers/entry-watcher/index.js
@@ -1,0 +1,60 @@
+"use strict";
+
+const bucker = require("bucker");
+const _ = require("lodash");
+const watchers = require("./lib/watchers");
+
+const noop = () => {};
+
+class EntryWatchcer {
+  constructor(options, cb) {
+    if (!options) options = {};
+
+    options = _.defaults(options, {
+      logger: bucker.createNullLogger(),
+      type: null,
+      auth: {},
+      onSave: noop,
+      onError: noop,
+    });
+
+    if (
+      options.onSave === noop &&
+      options.onError === noop &&
+      typeof cb === "function"
+    ) {
+      options.onSave = (entry) => cb(null, entry);
+      options.onError = (err) => cb(err);
+    }
+
+    if (!options.tags || !options.tags.length || !options.domain) {
+      throw new Error(
+        `Tags and domain are required. Got ${options.tags} ${options.domain}`
+      );
+    }
+
+    if (!options.sport || !options.year) {
+      throw new Error(
+        `Needs sport and year. Got ${options.sport} ${options.year}`
+      );
+    }
+
+    if (!watchers[options.type]) {
+      throw new Error(`${options.type} is not a valid entry type`);
+    }
+
+    this.options = options;
+  }
+
+  start() {
+    watchers[this.options.type](_.extend({}, this.options));
+  }
+
+  find(id) {
+    watchers[`find${_.startCase(this.options.type)}`](
+      _.extend({ id }, this.options)
+    );
+  }
+}
+
+module.exports = EntryWatchcer;

--- a/watchers/entry-watcher/lib/entry.js
+++ b/watchers/entry-watcher/lib/entry.js
@@ -1,0 +1,159 @@
+/* eslint-disable camelcase */
+
+"use strict";
+
+const async = require("async");
+const bucker = require("bucker");
+const moment = require("moment");
+const _ = require("lodash");
+const BracketFinder = require("../../bracket-finder");
+const Locks = require("./locks");
+
+const ENTRY_TYPES = {
+  tweet: {
+    dateFormat: "ddd MMM DD HH:mm:ss ZZ YYYY",
+    entry: (data) => ({
+      created: data.created_at,
+      user_id: data.user.id_str,
+      data_id: data.id_str,
+      username: data.user.screen_name,
+      name: data.user.name,
+      profile_pic: data.user.profile_image_url,
+      link: `${data.user.screen_name}/${data.id_str}`,
+    }),
+    validate: (entry, cb) => {
+      if (entry.hasOwnProperty("retweeted_status")) {
+        return cb(new Error("Tweet is a retweet"));
+      }
+
+      return cb(null);
+    },
+  },
+};
+
+class Entry {
+  constructor(options) {
+    if (options.tweet) {
+      this.type = "tweet";
+      this.entry = ENTRY_TYPES[this.type].entry(options.tweet);
+      this.originalData = options.tweet;
+    }
+
+    _.defaults(options, {
+      finder: new BracketFinder(
+        _.pick(options, "sport", "year", "domain", "tags")
+      ),
+      logger: bucker.createNullLogger(),
+      locks: new Locks({ year: options.year, sport: options.sport }),
+      onSave() {},
+      onError() {},
+    });
+
+    _.extend(
+      this,
+      _.pick(
+        options,
+        "getId",
+        "logger",
+        "finder",
+        "save",
+        "locks",
+        "onSave",
+        "onError"
+      )
+    );
+
+    if (!this.entry) {
+      throw new Error("Cant create an entry without data");
+    }
+
+    this.logger.info(
+      "[ENTRY]",
+      JSON.stringify({
+        original_data: this.originalData,
+        entry: this.entry,
+      })
+    );
+
+    this.save();
+  }
+
+  // -----------------------
+  // Validation
+  // -----------------------
+  typeValidation(cb) {
+    ENTRY_TYPES[this.type].validate(this.originalData, cb);
+  }
+
+  isOnTime(cb) {
+    if (
+      moment(this.entry.created, ENTRY_TYPES[this.type].dateFormat).isBefore(
+        this.locks.moment()
+      )
+    ) {
+      return cb(null);
+    }
+    return cb(new Error("Entry is outside of the allotted time"));
+  }
+
+  hasBracket(cb) {
+    const entryError = () =>
+      new Error(`${this.type} does not contain a bracket: ${this.entry.link}`);
+
+    this.finder[this.type](this.originalData, (err, result) => {
+      // Refetch tweet in case of an error that could be because the tweet was truncated
+      if (err && this.originalData.truncated && this.getId) {
+        return this.getId(this.entry.data_id, (getIdErr, fullTweet) => {
+          if (getIdErr) {
+            this.logger.error("[GET ID ERROR]", getIdErr.message);
+            return cb(entryError());
+          }
+
+          this.logger.info("[GET ID]", JSON.stringify(fullTweet));
+
+          this.originalData = fullTweet;
+          this.originalData.truncated = false;
+          return this.hasBracket(cb);
+        });
+      }
+
+      if (err) {
+        return cb(entryError());
+      }
+
+      return cb(null, result);
+    });
+  }
+
+  isValid(cb) {
+    async.series(
+      [
+        this.typeValidation.bind(this),
+        this.isOnTime.bind(this),
+        this.hasBracket.bind(this),
+      ],
+      (err, result) => cb(err, result && result[2])
+    );
+  }
+
+  // -----------------------
+  // Saving
+  // -----------------------
+  save() {
+    this.isValid((err, bracket) => {
+      if (err) {
+        this.logger.error("[VALIDATION]", err.message);
+        this.onError(err);
+      } else {
+        this.entry.bracket = bracket;
+        this.logger.info(
+          "[SAVE]",
+          JSON.stringify(_.pick(this.entry, "username", "bracket"))
+        );
+        this.onSave(this.entry);
+      }
+    });
+  }
+}
+
+module.exports = Entry;

--- a/watchers/entry-watcher/lib/locks.js
+++ b/watchers/entry-watcher/lib/locks.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const moment = require("moment");
+const bracketData = require("bracket-data");
+
+const MAX_TIMEOUT = 2147483647;
+
+class Locks {
+  constructor(options) {
+    this.locks = moment(
+      options.locks ||
+        bracketData({
+          year: options.year,
+          sport: options.sport,
+        }).locks
+    );
+  }
+
+  isOpen() {
+    return moment().isBefore(this.locks);
+  }
+
+  closesIn() {
+    // JS cant set a timeout for longer than MAX_TIMEOUT
+    // so that is returned if the diff is larger than that.
+    // This could cause problems if it needs to lock more than ~24
+    // days in the future, but that wont happen under current circumstances.
+    return Math.min(this.locks.diff(moment()), MAX_TIMEOUT);
+  }
+
+  moment(prop) {
+    if (prop) return this.locks[prop]();
+    return this.locks;
+  }
+}
+
+module.exports = Locks;

--- a/watchers/entry-watcher/lib/watchers.js
+++ b/watchers/entry-watcher/lib/watchers.js
@@ -1,0 +1,130 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-new */
+
+"use strict";
+
+const Twit = require("twit");
+const _ = require("lodash");
+const Entry = require("./entry");
+const Locks = require("./locks");
+
+const canWatch = (options, cb) => {
+  if (options._forceOpen) {
+    return cb();
+  }
+
+  const locks = new Locks(_.pick(options, "year", "sport"));
+  const lockDisplay = `${locks.moment("calendar")} / ${locks.moment(
+    "fromNow"
+  )}`;
+
+  if (locks.isOpen()) {
+    options.logger.info(
+      "[START WATCHER]",
+      `track: ${options.tags.join()}`,
+      "until",
+      lockDisplay
+    );
+    return cb(locks);
+  }
+
+  options.logger.info("[NO STREAM]", "at", lockDisplay);
+  return null;
+};
+
+const tweet = (options) =>
+  canWatch(options, (locks) => {
+    const { logger } = options;
+
+    const T = new Twit(options.auth);
+
+    // Im not sure if tweet_mode: extended works on streams, so as a backup the entry validator
+    // takes a fn to lookup the individual tweet in case of an error
+    const stream = T.stream("statuses/filter", {
+      track: options.tags,
+      tweet_mode: "extended",
+    });
+
+    stream.on("tweet", (data) => {
+      new Entry(
+        _.extend({}, _.pick(options, "sport", "year", "domain", "tags"), {
+          getId: (id, cb) =>
+            T.get("statuses/show", { id, tweet_mode: "extended" }, cb),
+          tweet: data,
+          logger,
+          onSave: options.onSave,
+          onError: options.onError,
+        })
+      );
+    });
+
+    stream.on("disconnect", (message) => {
+      logger.error("[DISCONNECT]", message);
+    });
+
+    stream.on("error", (err) => {
+      logger.error("[ERROR]", err);
+    });
+
+    stream.on("connect", () => {
+      logger.info("[CONNECT]");
+    });
+
+    stream.on("reconnect", () => {
+      logger.warn("[RECONNECT]");
+    });
+
+    stream.on("limit", (msg) => {
+      logger.warn("[LIMIT]", msg);
+    });
+
+    stream.on("warning", (msg) => {
+      logger.warn("[WARNING]", msg);
+    });
+
+    if (locks) {
+      setTimeout(() => {
+        logger.info("[STOP STREAM]");
+        stream.stop();
+      }, locks.closesIn());
+    }
+  });
+
+const findTweet = (options) => {
+  const { logger } = options;
+
+  const T = new Twit(options.auth);
+
+  T.get(
+    "statuses/show",
+    { id: options.id, tweet_mode: "extended" },
+    (err, tweetStatus) => {
+      if (err) {
+        logger.error("[FIND TWEET]", err);
+        if (options.onError) options.onError(err);
+        return;
+      }
+
+      new Entry(
+        _.extend(
+          { tweet: tweetStatus },
+          _.pick(
+            options,
+            "sport",
+            "year",
+            "domain",
+            "tags",
+            "logger",
+            "onSave",
+            "onError"
+          )
+        )
+      );
+    }
+  );
+};
+
+module.exports = {
+  tweet,
+  findTweet,
+};

--- a/watchers/entry-watcher/readme.md
+++ b/watchers/entry-watcher/readme.md
@@ -1,0 +1,50 @@
+# entry-watcher
+
+Entry watcher for [bracket.club](https://bracket.club).
+
+## Usage
+
+```js
+const EntryWatcher = require('entry-watcher');
+new EntryWatcher({
+  logger: null,
+  sport: 'ncaam',
+  year: '2015',
+  domain: 'bracket.club',
+  tags: ['bracketclub'],
+  type: 'tweet',
+  auth: {
+    // Passed to twitter streaming listener
+    // Could be extended in the future based on `options.type`
+    'consumer_key': '',
+    'consumer_secret': '',
+    'access_token': '',
+    'access_token_secre': ''
+  }
+  onSave: function (entry) {
+    // Entry is the full entry passsed back
+    // plus the `bracket` value
+  },
+  onError: function () {
+    // Can be used to plug in to when there are entries
+    // that dont meet the validation such as not having a valid
+    // bracket or being outside the time limit
+  }
+}).start();
+```
+
+## Checking a Specific Tweet
+
+```js
+new EntryWatcher({
+  // All the same options as above
+}).find(TWEET_ID);
+```
+
+## What is it doing?
+
+It is setting up a Twitter listener using [`twit`](https://github.com/ttezel/twit) and when a tweet is found, it is checking whether it contains a valid bracket. If it does, it will call the `onSave` handler.
+
+### LICENSE
+
+MIT

--- a/watchers/entry-watcher/test/data/notag-domain-nobracket.json
+++ b/watchers/entry-watcher/test/data/notag-domain-nobracket.json
@@ -1,0 +1,91 @@
+{
+  "created_at": "Sun Jan 26 00:15:58 +0000 2014",
+  "id": 427233416044490752,
+  "id_str": "427233416044490752",
+  "text": "Tweet Your Bracket is almost here!\n\nhttp://t.co/ISprxtPnBs",
+  "source": "<a href=\"http://twitter.com/tweetbutton\" rel=\"nofollow\">Tweet Button</a>",
+  "truncated": false,
+  "in_reply_to_status_id": null,
+  "in_reply_to_status_id_str": null,
+  "in_reply_to_user_id": null,
+  "in_reply_to_user_id_str": null,
+  "in_reply_to_screen_name": null,
+  "user": {
+    "id": 515832256,
+    "id_str": "515832256",
+    "name": "Tweet Your Bracket",
+    "screen_name": "TweetTheBracket",
+    "location": "",
+    "description": "Share your NCAA Tournament bracket through Twitter.",
+    "url": "http://t.co/ISprxtPnBs",
+    "entities": {
+      "url": {
+        "urls": [
+          {
+            "url": "http://t.co/ISprxtPnBs",
+            "expanded_url": "http://lookforthisdomain.com",
+            "display_url": "lookforthisdomain.com",
+            "indices": [0, 22]
+          }
+        ]
+      },
+      "description": {
+        "urls": []
+      }
+    },
+    "protected": false,
+    "followers_count": 29,
+    "friends_count": 24,
+    "listed_count": 0,
+    "created_at": "Mon Mar 05 20:25:23 +0000 2012",
+    "favourites_count": 0,
+    "utc_offset": -25200,
+    "time_zone": "Arizona",
+    "geo_enabled": false,
+    "verified": false,
+    "statuses_count": 84,
+    "lang": "en",
+    "contributors_enabled": false,
+    "is_translator": false,
+    "is_translation_enabled": false,
+    "profile_background_color": "C0DEED",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_tile": false,
+    "profile_image_url": "http://pbs.twimg.com/profile_images/1896286168/1A918E19-45FC-47CF-A945-CF1C247AEB09_normal",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1896286168/1A918E19-45FC-47CF-A945-CF1C247AEB09_normal",
+    "profile_link_color": "0084B4",
+    "profile_sidebar_border_color": "C0DEED",
+    "profile_sidebar_fill_color": "DDEEF6",
+    "profile_text_color": "333333",
+    "profile_use_background_image": true,
+    "default_profile": true,
+    "default_profile_image": false,
+    "following": false,
+    "follow_request_sent": false,
+    "notifications": false
+  },
+  "geo": null,
+  "coordinates": null,
+  "place": null,
+  "contributors": null,
+  "retweet_count": 1,
+  "favorite_count": 0,
+  "entities": {
+    "hashtags": [],
+    "symbols": [],
+    "urls": [
+      {
+        "url": "http://t.co/ISprxtPnBs",
+        "expanded_url": "http://lookforthisdomain.com",
+        "display_url": "lookforthisdomain.com",
+        "indices": [36, 58]
+      }
+    ],
+    "user_mentions": []
+  },
+  "favorited": false,
+  "retweeted": false,
+  "possibly_sensitive": false,
+  "lang": "en"
+}

--- a/watchers/entry-watcher/test/data/notag-nodomain-nobracket.json
+++ b/watchers/entry-watcher/test/data/notag-nodomain-nobracket.json
@@ -1,0 +1,96 @@
+{
+  "created_at": "Wed Feb 26 19:24:42 +0000 2014",
+  "id": 438756526988087296,
+  "id_str": "438756526988087296",
+  "text": "Dart 1.2 stable release includes improved debugging, faster networking, and Angular support in the Editor. http://t.co/PcBFJiakOJ #dartlang",
+  "source": "web",
+  "truncated": false,
+  "in_reply_to_status_id": null,
+  "in_reply_to_status_id_str": null,
+  "in_reply_to_user_id": null,
+  "in_reply_to_user_id_str": null,
+  "in_reply_to_screen_name": null,
+  "user": {
+    "id": 376585411,
+    "id_str": "376585411",
+    "name": "Google's Dart Team",
+    "screen_name": "dart_lang",
+    "location": "",
+    "description": "Structured web programming.",
+    "url": "http://t.co/mBUv1XRAeY",
+    "entities": {
+      "url": {
+        "urls": [
+          {
+            "url": "http://t.co/mBUv1XRAeY",
+            "expanded_url": "http://dartlang.org",
+            "display_url": "dartlang.org",
+            "indices": [0, 22]
+          }
+        ]
+      },
+      "description": {
+        "urls": []
+      }
+    },
+    "protected": false,
+    "followers_count": 8814,
+    "friends_count": 19,
+    "listed_count": 318,
+    "created_at": "Tue Sep 20 04:21:29 +0000 2011",
+    "favourites_count": 3,
+    "utc_offset": null,
+    "time_zone": null,
+    "geo_enabled": false,
+    "verified": false,
+    "statuses_count": 911,
+    "lang": "en",
+    "contributors_enabled": false,
+    "is_translator": false,
+    "is_translation_enabled": false,
+    "profile_background_color": "FFFFFF",
+    "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/343957595/twitter_bkgd.png",
+    "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/343957595/twitter_bkgd.png",
+    "profile_background_tile": false,
+    "profile_image_url": "http://pbs.twimg.com/profile_images/1581261324/Twitter-02_normal.png",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1581261324/Twitter-02_normal.png",
+    "profile_link_color": "0081C6",
+    "profile_sidebar_border_color": "FFFFFF",
+    "profile_sidebar_fill_color": "F2F2F2",
+    "profile_text_color": "000000",
+    "profile_use_background_image": false,
+    "default_profile": false,
+    "default_profile_image": false,
+    "following": false,
+    "follow_request_sent": false,
+    "notifications": false
+  },
+  "geo": null,
+  "coordinates": null,
+  "place": null,
+  "contributors": null,
+  "retweet_count": 41,
+  "favorite_count": 18,
+  "entities": {
+    "hashtags": [
+      {
+        "text": "dartlang",
+        "indices": [130, 139]
+      }
+    ],
+    "symbols": [],
+    "urls": [
+      {
+        "url": "http://t.co/PcBFJiakOJ",
+        "expanded_url": "http://news.dartlang.org/2014/02/dart-v1-2.html",
+        "display_url": "news.dartlang.org/2014/02/dart-v…",
+        "indices": [107, 129]
+      }
+    ],
+    "user_mentions": []
+  },
+  "favorited": false,
+  "retweeted": false,
+  "possibly_sensitive": false,
+  "lang": "en"
+}

--- a/watchers/entry-watcher/test/data/tag-domain-bracket.json
+++ b/watchers/entry-watcher/test/data/tag-domain-bracket.json
@@ -1,0 +1,105 @@
+{
+  "created_at": "Wed Mar 20 02:26:17 +0000 2013",
+  "id": 314201194597871616,
+  "id_str": "314201194597871616",
+  "text": "L'ville vs IU. What can I say, I love chalk. http://t.co/imfF2NZyYF #somehashtaggggg via @tweetthebracket",
+  "source": "<a href=\"http://twitter.com/tweetbutton\" rel=\"nofollow\">Tweet Button</a>",
+  "truncated": false,
+  "in_reply_to_status_id": null,
+  "in_reply_to_status_id_str": null,
+  "in_reply_to_user_id": null,
+  "in_reply_to_user_id_str": null,
+  "in_reply_to_screen_name": null,
+  "user": {
+    "id": 23918006,
+    "id_str": "23918006",
+    "name": "Luke Karrys",
+    "screen_name": "lukekarrys",
+    "location": "Arizona",
+    "description": "Internet maker @andyet. AZ mountain man. Bicycle rider. Music appreciator. I @TweetTheBracket. Engaged to @DinahPugLife.",
+    "url": "http://t.co/mfNkdEmTfD",
+    "entities": {
+      "url": {
+        "urls": [
+          {
+            "url": "http://t.co/mfNkdEmTfD",
+            "expanded_url": "http://lukekarrys.com",
+            "display_url": "lukekarrys.com",
+            "indices": [0, 22]
+          }
+        ]
+      },
+      "description": {
+        "urls": []
+      }
+    },
+    "protected": false,
+    "followers_count": 712,
+    "friends_count": 300,
+    "listed_count": 48,
+    "created_at": "Thu Mar 12 07:40:45 +0000 2009",
+    "favourites_count": 706,
+    "utc_offset": -25200,
+    "time_zone": "Arizona",
+    "geo_enabled": true,
+    "verified": false,
+    "statuses_count": 8927,
+    "lang": "en",
+    "contributors_enabled": false,
+    "is_translator": false,
+    "is_translation_enabled": false,
+    "profile_background_color": "1A1B1F",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme9/bg.gif",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme9/bg.gif",
+    "profile_background_tile": false,
+    "profile_image_url": "http://pbs.twimg.com/profile_images/3310194461/3caaee2149bcbcc0db17a8456510880f_normal.jpeg",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/3310194461/3caaee2149bcbcc0db17a8456510880f_normal.jpeg",
+    "profile_banner_url": "https://pbs.twimg.com/profile_banners/23918006/1358317710",
+    "profile_link_color": "2FC2EF",
+    "profile_sidebar_border_color": "181A1E",
+    "profile_sidebar_fill_color": "252429",
+    "profile_text_color": "666666",
+    "profile_use_background_image": true,
+    "default_profile": false,
+    "default_profile_image": false,
+    "following": true,
+    "follow_request_sent": false,
+    "notifications": false
+  },
+  "geo": null,
+  "coordinates": null,
+  "place": null,
+  "contributors": null,
+  "retweet_count": 0,
+  "favorite_count": 0,
+  "entities": {
+    "hashtags": [
+      {
+        "text": "somehashtaggggg",
+        "indices": [68, 75]
+      }
+    ],
+    "symbols": [],
+    "urls": [
+      {
+        "url": "http://t.co/imfF2NZyYF",
+        "expanded_url": "http://lookforthisdomain.com/#MW191241137211237131W1854631021532522S18541131021532533E195463721432121FFMWEMW",
+        "display_url": "lookforthisdomain.com/#MW19124113721…",
+        "indices": [45, 67]
+      }
+    ],
+    "user_mentions": [
+      {
+        "screen_name": "TweetTheBracket",
+        "name": "Tweet Your Bracket",
+        "id": 515832256,
+        "id_str": "515832256",
+        "indices": [80, 96]
+      }
+    ]
+  },
+  "favorited": false,
+  "retweeted": false,
+  "possibly_sensitive": false,
+  "lang": "en"
+}

--- a/watchers/entry-watcher/test/data/tag-domain-nobracket.json
+++ b/watchers/entry-watcher/test/data/tag-domain-nobracket.json
@@ -1,0 +1,96 @@
+{
+  "created_at": "Wed Feb 26 20:43:07 +0000 2014",
+  "id": 438776262480232450,
+  "id_str": "438776262480232450",
+  "text": "18 days until brackets open!We are excited and testing the new site. Sign up to be notified when it’s ready: http://t.co/UXj61QfOlc\n\n#somehashtaggggg",
+  "source": "<a href=\"http://tapbots.com/software/tweetbot/mac\" rel=\"nofollow\">Tweetbot for Mac</a>",
+  "truncated": false,
+  "in_reply_to_status_id": null,
+  "in_reply_to_status_id_str": null,
+  "in_reply_to_user_id": null,
+  "in_reply_to_user_id_str": null,
+  "in_reply_to_screen_name": null,
+  "user": {
+    "id": 515832256,
+    "id_str": "515832256",
+    "name": "Tweet Your Bracket",
+    "screen_name": "TweetTheBracket",
+    "location": "",
+    "description": "Share your NCAA Tournament bracket through Twitter.",
+    "url": "http://t.co/ISprxtPnBs",
+    "entities": {
+      "url": {
+        "urls": [
+          {
+            "url": "http://t.co/ISprxtPnBs",
+            "expanded_url": "http://lookforthisdomain.com",
+            "display_url": "lookforthisdomain.com",
+            "indices": [0, 22]
+          }
+        ]
+      },
+      "description": {
+        "urls": []
+      }
+    },
+    "protected": false,
+    "followers_count": 29,
+    "friends_count": 24,
+    "listed_count": 0,
+    "created_at": "Mon Mar 05 20:25:23 +0000 2012",
+    "favourites_count": 0,
+    "utc_offset": -25200,
+    "time_zone": "Arizona",
+    "geo_enabled": false,
+    "verified": false,
+    "statuses_count": 85,
+    "lang": "en",
+    "contributors_enabled": false,
+    "is_translator": false,
+    "is_translation_enabled": false,
+    "profile_background_color": "C0DEED",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_tile": false,
+    "profile_image_url": "http://pbs.twimg.com/profile_images/1896286168/1A918E19-45FC-47CF-A945-CF1C247AEB09_normal",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1896286168/1A918E19-45FC-47CF-A945-CF1C247AEB09_normal",
+    "profile_link_color": "0084B4",
+    "profile_sidebar_border_color": "C0DEED",
+    "profile_sidebar_fill_color": "DDEEF6",
+    "profile_text_color": "333333",
+    "profile_use_background_image": true,
+    "default_profile": true,
+    "default_profile_image": false,
+    "following": false,
+    "follow_request_sent": false,
+    "notifications": false
+  },
+  "geo": null,
+  "coordinates": null,
+  "place": null,
+  "contributors": null,
+  "retweet_count": 0,
+  "favorite_count": 0,
+  "entities": {
+    "hashtags": [
+      {
+        "text": "somehashtaggggg",
+        "indices": [133, 140]
+      }
+    ],
+    "symbols": [],
+    "urls": [
+      {
+        "url": "http://t.co/UXj61QfOlc",
+        "expanded_url": "http://lookforthisdomain.com/",
+        "display_url": "lookforthisdomain.com",
+        "indices": [109, 131]
+      }
+    ],
+    "user_mentions": []
+  },
+  "favorited": false,
+  "retweeted": false,
+  "possibly_sensitive": false,
+  "lang": "en"
+}

--- a/watchers/entry-watcher/test/data/tag-shortdomain-bracket.json
+++ b/watchers/entry-watcher/test/data/tag-shortdomain-bracket.json
@@ -1,0 +1,86 @@
+{
+  "created_at": "Wed Feb 26 20:48:05 +0000 2014",
+  "id": 438777510063378432,
+  "id_str": "438777510063378432",
+  "text": "http://bit.ly/2FJABbv #somehashtaggggg",
+  "source": "<a href=\"http://tapbots.com/software/tweetbot/mac\" rel=\"nofollow\">Tweetbot for Mac</a>",
+  "truncated": false,
+  "in_reply_to_status_id": null,
+  "in_reply_to_status_id_str": null,
+  "in_reply_to_user_id": null,
+  "in_reply_to_user_id_str": null,
+  "in_reply_to_screen_name": null,
+  "user": {
+    "id": 332423991,
+    "id_str": "332423991",
+    "name": "Other Account",
+    "screen_name": "lukekarryz",
+    "location": "",
+    "description": "",
+    "url": null,
+    "entities": {
+      "description": {
+        "urls": []
+      }
+    },
+    "protected": false,
+    "followers_count": 0,
+    "friends_count": 0,
+    "listed_count": 0,
+    "created_at": "Sat Jul 09 19:44:14 +0000 2011",
+    "favourites_count": 0,
+    "utc_offset": -18000,
+    "time_zone": "Eastern Time (US & Canada)",
+    "geo_enabled": false,
+    "verified": false,
+    "statuses_count": 2,
+    "lang": "en",
+    "contributors_enabled": false,
+    "is_translator": false,
+    "is_translation_enabled": false,
+    "profile_background_color": "C0DEED",
+    "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+    "profile_background_tile": false,
+    "profile_image_url": "http://abs.twimg.com/sticky/default_profile_images/default_profile_4_normal.png",
+    "profile_image_url_https": "https://abs.twimg.com/sticky/default_profile_images/default_profile_4_normal.png",
+    "profile_link_color": "0084B4",
+    "profile_sidebar_border_color": "C0DEED",
+    "profile_sidebar_fill_color": "DDEEF6",
+    "profile_text_color": "333333",
+    "profile_use_background_image": true,
+    "default_profile": true,
+    "default_profile_image": true,
+    "following": false,
+    "follow_request_sent": false,
+    "notifications": false
+  },
+  "geo": null,
+  "coordinates": null,
+  "place": null,
+  "contributors": null,
+  "retweet_count": 0,
+  "favorite_count": 0,
+  "entities": {
+    "hashtags": [
+      {
+        "text": "somehashtaggggg",
+        "indices": [23, 30]
+      }
+    ],
+    "symbols": [],
+    "urls": [
+      {
+        "url": "http://bit.ly/2FJABbv",
+        "expanded_url": "http://bit.ly/2FJABbv",
+        "display_url": "bit.ly/2FJABbv",
+        "indices": [0, 22]
+      }
+    ],
+    "user_mentions": []
+  },
+  "favorited": false,
+  "retweeted": false,
+  "possibly_sensitive": false,
+  "lang": "de"
+}

--- a/watchers/entry-watcher/test/entry.js
+++ b/watchers/entry-watcher/test/entry.js
@@ -1,0 +1,137 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-env mocha */
+/* eslint-disable no-new */
+
+"use strict";
+
+const assert = require("assert");
+const _ = require("lodash");
+const moment = require("moment");
+
+const Entry = require("../lib/entry");
+const Locks = require("../lib/locks");
+
+const year = "2013";
+const sport = "ncaam";
+const config = { domain: "lookforthisdomain.com", tags: ["somehashtaggggg"] };
+
+const entryConfig = (opts) => _.extend({}, config, opts, { year, sport });
+const future = moment().add(10, "days").utc().format();
+
+const locks = (obj) => new Locks(_.extend(obj || {}, { sport, year }));
+
+const noError = (done) => (err) => {
+  assert.equal(err, null);
+  done();
+};
+
+describe("Entry watcher [twitter]", () => {
+  it("Should find a valid bracket from a tweet with a domain+bracket and bracket", (done) => {
+    new Entry(
+      entryConfig({
+        tweet: require("./data/tag-domain-bracket"),
+        onSave: (result) => {
+          assert.equal(
+            result.bracket,
+            "MW191241137211237131W1854631021532522S18541131021532533E195463721432121FFMWEMW"
+          );
+          done();
+        },
+        onError: noError(done),
+      })
+    );
+  });
+
+  it("Should fail since entries are locked", (done) => {
+    new Entry(
+      entryConfig({
+        locks: locks({ locks: "2013-03-20T02:25:17.000Z" }),
+        tweet: require("./data/tag-domain-bracket"),
+        onError: (err) => {
+          assert.equal(true, err instanceof Error);
+          assert.equal(err.message, "Entry is outside of the allotted time");
+          done();
+        },
+      })
+    );
+  });
+
+  it("Should not find a valid bracket from a tweet with a domain-bracket and tags", (done) => {
+    new Entry(
+      entryConfig({
+        locks: locks({ locks: future }),
+        tweet: require("./data/tag-domain-nobracket"),
+        onError: (err) => {
+          assert.equal(true, err instanceof Error);
+          assert.equal(
+            err.message,
+            "tweet does not contain a bracket: TweetTheBracket/438776262480232450"
+          );
+          done();
+        },
+      })
+    );
+  });
+
+  it("Should find a valid bracket from a tweet with a short domain+bracket and tags", (done) => {
+    new Entry(
+      entryConfig({
+        domain: "bracket.club",
+        locks: locks({ locks: future }),
+        tweet: require("./data/tag-shortdomain-bracket"),
+        sport,
+        year,
+        onSave: (result) => {
+          assert.equal(
+            result.bracket,
+            "MW18121311372112117177W168124631028123101233S181241131028411104114E1954614721462466FFWSS"
+          );
+          done();
+        },
+        onError: noError(done),
+      })
+    );
+  });
+
+  // notag-domain-nobracket
+  it("Should not find a bracket from a tweet with a domain but nothing else", (done) => {
+    new Entry(
+      entryConfig({
+        locks: locks({ locks: future }),
+        tweet: require("./data/notag-domain-nobracket"),
+        onError: (err) => {
+          assert.equal(true, err instanceof Error);
+          assert.equal(
+            err.message,
+            "tweet does not contain a bracket: TweetTheBracket/427233416044490752"
+          );
+          done();
+        },
+      })
+    );
+  });
+
+  // notag-nodomain-nobracket
+  it("Should not find a bracket from a tweet with nothing", (done) => {
+    new Entry(
+      entryConfig({
+        locks: locks({ locks: future }),
+        tweet: require("./data/notag-nodomain-nobracket"),
+        onError: (err) => {
+          assert.equal(true, err instanceof Error);
+          assert.equal(
+            err.message,
+            "tweet does not contain a bracket: dart_lang/438756526988087296"
+          );
+          done();
+        },
+      })
+    );
+  });
+
+  it("Should throw an error if entry is created with no data", () => {
+    assert.throws(() => {
+      new Entry(entryConfig());
+    });
+  });
+});

--- a/watchers/entry-watcher/test/index.js
+++ b/watchers/entry-watcher/test/index.js
@@ -1,0 +1,73 @@
+/* eslint-disable camelcase */
+/* eslint-env mocha */
+
+"use strict";
+
+const assert = require("assert");
+const Watcher = require("../index");
+
+describe("Watcher", () => {
+  it("Should throw an error if a watcher has no domain or tags", () => {
+    assert.throws(() => {
+      new Watcher({
+        sport: "ncaam",
+        year: "2016",
+        type: "tweet",
+        domain: null,
+        tags: [],
+      }).start();
+    });
+  });
+
+  it("Should not throw an error if a watcher has twitter type and auth", () => {
+    assert.doesNotThrow(() => {
+      new Watcher({
+        sport: "ncaam",
+        year: "2016",
+        domain: "somedomain.com",
+        tags: ["tagggg"],
+        type: "tweet",
+        auth: {
+          consumer_key: "1",
+          consumer_secret: "2",
+          access_token: "3",
+          access_token_secret: "4",
+        },
+      }).start();
+    });
+  });
+
+  it("Should throw an error if a watcher has no sport year", () => {
+    assert.throws(() => {
+      new Watcher({
+        domain: "somedomain.com",
+        tags: ["tagggg"],
+      }).start();
+    }, /Needs sport and year/);
+  });
+
+  it("Should throw an error if a watcher has twitter type and no auth", () => {
+    assert.throws(() => {
+      new Watcher({
+        sport: "ncaam",
+        year: "2016",
+        type: "tweet",
+        domain: "somedomain.com",
+        tags: ["tagggg"],
+        _forceOpen: true,
+      }).start();
+    }, /Twit config must include `consumer_key` when using user auth/);
+  });
+
+  it("Should throw an error if a watcher has no type", () => {
+    assert.throws(() => {
+      new Watcher({
+        sport: "ncaam",
+        year: "2016",
+        type: "x",
+        domain: "somedomain.com",
+        tags: ["tagggg"],
+      }).start();
+    }, /x is not a valid entry type/);
+  });
+});

--- a/watchers/entry-watcher/test/locks.js
+++ b/watchers/entry-watcher/test/locks.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-magic-numbers */
+/* eslint-env mocha */
+
+"use strict";
+
+const assert = require("assert");
+const moment = require("moment");
+const Locks = require("../lib/locks");
+
+const year = "2013";
+const sport = "ncaam";
+const ONE_DAY = 1000 * 60 * 60 * 24;
+
+describe("Locks", () => {
+  it("Works with a sport year", (done) => {
+    const locks = new Locks({ year, sport });
+
+    assert.equal(locks.isOpen(), false);
+    assert.equal(locks.moment("calendar"), "03/21/2013");
+
+    done();
+  });
+
+  it("Works with a future lock time", (done) => {
+    const future = moment().add(ONE_DAY, "ms").utc().format();
+    const locks = new Locks({ locks: future });
+
+    assert.equal(locks.isOpen(), true);
+    assert.ok(locks.closesIn() > ONE_DAY - 10000);
+
+    done();
+  });
+});

--- a/watchers/score-watcher/index.js
+++ b/watchers/score-watcher/index.js
@@ -1,0 +1,141 @@
+"use strict";
+
+const bucker = require("bucker");
+const _ = require("lodash");
+const Scores = require("scores");
+const BracketUpdater = require("bracket-updater");
+const bracketData = require("bracket-data");
+const async = require("async");
+
+class Watcher {
+  constructor(options) {
+    this.options = _.defaults(options || {}, {
+      logger: null,
+      master: "",
+      onSave() {},
+      onDrain() {},
+      scores: {},
+    });
+
+    if (!options.sport || !options.year) {
+      throw new Error(
+        `Needs sport and year. Got ${options.sport} ${options.year}`
+      );
+    }
+
+    const { sport, year } = this.options;
+    const empty = bracketData({ year, sport }).constants.EMPTY;
+    const master = this.options.master || empty;
+
+    if (!sport || !year) {
+      throw new Error("Needs a sport and a year");
+    }
+
+    // The logger will be passed to the score watcher to log everything there.
+    this.logger = this.options.logger || bucker.createNullLogger();
+
+    // Create the score watcher
+    this.scores = new Scores(
+      _.extend({ logger: this.logger }, this.options.scores)
+    );
+    this.scores.on("event", this.onEvent.bind(this));
+
+    // Create our bracket update with the initial master to be updated
+    this.updater = new BracketUpdater({
+      sport,
+      year,
+      currentMaster: master,
+    });
+
+    // Helpful for debugging how the watcher was started
+    this.logger.info(
+      "[INIT SCOREWATCHER]",
+      JSON.stringify({ master, year, sport })
+    );
+
+    // Queue ensures that even if the score watcher emits
+    // more than one event, we can still update the master bracket
+    // in order, by optionally passing a callback to onSave
+    this.queue = async.queue(this.queueWorker.bind(this), 1);
+
+    // Drain is mostly just used in tests
+    this.queue.drain = this.options.onDrain;
+  }
+
+  queueWorker(event, cb) {
+    this.logger.info("[EVENT QUEUED]", JSON.stringify(event));
+
+    const updated = this.updater.update(event);
+
+    if (updated instanceof Error) {
+      this.logger.error(
+        "[UPDATE FAILED]",
+        JSON.stringify({
+          event,
+          err: updated.message,
+          master: this.updater.currentMaster,
+        })
+      );
+      return process.nextTick(cb);
+    }
+
+    this.logger.info("[UPDATED]", updated);
+
+    // If we have a callback, then use that async
+    if (this.options.onSave.length === 2) {
+      return this.options.onSave(updated, cb);
+    }
+
+    this.options.onSave(updated);
+    return process.nextTick(cb);
+  }
+
+  onEvent(event) {
+    // Team will look like this:
+    // { seed: 1, name: ['array of', 'some names'], winner: true }
+    const transformTeam = (team) =>
+      _.transform(
+        _.pick(team, "names", "rank", "winner"),
+        (res, value, key) => {
+          if (key === "names") {
+            res.name = value;
+          } else if (key === "rank") {
+            res.seed = value;
+          } else {
+            res[key] = value;
+          }
+        },
+        {}
+      );
+
+    const result = {
+      playedCompetitions: event.playedCompetitions,
+      fromRegion: event.region,
+      winner: transformTeam(event.home.winner ? event.home : event.away),
+      loser: transformTeam(event.home.winner ? event.away : event.home),
+    };
+
+    if (!result.winner || !result.loser || !result.fromRegion) {
+      this.logger.error("[INVALID RESULT]", JSON.stringify(result));
+    } else {
+      const duplicateTask = _.find(
+        _.map(this.queue.workersList(), "data"),
+        result
+      );
+
+      // Dont allow games that are already in the queue to be added again
+      if (duplicateTask) {
+        this.logger.warn("[DUPLICATE UPDATE]", JSON.stringify(result));
+      } else {
+        this.queue.push(result);
+      }
+    }
+  }
+
+  start() {
+    this.scores.start();
+    return this;
+  }
+}
+
+module.exports = Watcher;

--- a/watchers/score-watcher/readme.md
+++ b/watchers/score-watcher/readme.md
@@ -1,0 +1,40 @@
+# score-watcher
+
+Score watcher for [bracket.club](https://bracket.club).
+
+## Usage
+
+```js
+const ScoreWatcher = require("score-watcher");
+
+new ScoreWatcher({
+  // Required
+  sport: "ncaam",
+  year: "2015",
+  // An optional bracket to initialize the updater with
+  // Will default to an empty bracket for the sport/year
+  master: "",
+  // Optional log file
+  logger: null,
+  // The callbacks
+  onSave: function (master, cb) {
+    // Will be called with each master as a string
+    // `cb` is optional but should be used to ensure
+    // that each bracket is saved before moving to
+    // the next one
+  },
+  scores: {
+    // Config for scores module
+    interval: "1m",
+    url: "http://url.com",
+  },
+}).start();
+```
+
+## What is it doing?
+
+It is setting up an async.queue and creating a watcher/emitter with [`scores`](http://github.com/bracketclub/scores). Then every time the queue drains, it calls `onSave` with the latest master (and an optional callback to notify the watcher when it has been added).
+
+### LICENSE
+
+MIT

--- a/watchers/score-watcher/test/test.js
+++ b/watchers/score-watcher/test/test.js
@@ -1,0 +1,149 @@
+/* eslint no-magic-numbers:0 */
+
+"use strict";
+
+const _ = require("lodash");
+const test = require("tape");
+const bracketData = require("bracket-data");
+const Watcher = require("../index");
+
+const year = "2013";
+const sport = "ncaam";
+const data = bracketData({ year, sport });
+const { order, constants } = data;
+
+const scores = {
+  url: "http://mock-url-for-tests.com",
+};
+
+test("It should update the first round all at once", (t) => {
+  const masters = [];
+
+  const watcher = new Watcher({
+    scores,
+    year,
+    sport,
+    onSave(master) {
+      masters.push(master);
+    },
+    onDrain() {
+      t.equal(masters.length, 32);
+      t.equal(
+        _.last(masters),
+        "MW18546372XXXXXXXW18546372XXXXXXXS18546372XXXXXXXE18546372XXXXXXXFFXXX"
+      );
+      t.end();
+    },
+  }).scores;
+
+  constants.REGION_IDS.forEach((region) => {
+    for (let i = 0, m = order.length; i < m; i += 2) {
+      watcher.emit("event", {
+        region,
+        home: {
+          rank: order[i],
+          winner: true,
+        },
+        away: {
+          rank: order[i + 1],
+          winner: false,
+        },
+      });
+    }
+  });
+});
+
+test("It should update the first round separately if not queued and async", (t) => {
+  let drainCount = 0;
+  const masters = [];
+  const after = [
+    "MW1XXXXXXXXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW18XXXXXXXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW185XXXXXXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW1854XXXXXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW18546XXXXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW185463XXXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW1854637XXXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+    "MW18546372XXXXXXXWXXXXXXXXXXXXXXXSXXXXXXXXXXXXXXXEXXXXXXXXXXXXXXXFFXXX",
+  ];
+
+  const watcher = new Watcher({
+    scores,
+    year,
+    sport,
+    onSave(master, cb) {
+      masters.push(master);
+      t.equal(master, after[drainCount]);
+      drainCount++;
+      if (drainCount === 8) {
+        t.equal(masters.join(","), after.join(","));
+      }
+      setTimeout(() => cb(), _.random(100, 150));
+    },
+    onDrain() {
+      t.equal(drainCount, 8);
+      t.end();
+    },
+  }).scores;
+
+  for (let i = 0, m = order.length; i < m; i += 2) {
+    watcher.emit("event", {
+      region: "MW",
+      home: {
+        rank: order[i],
+        winner: true,
+      },
+      away: {
+        rank: order[i + 1],
+        winner: false,
+      },
+    });
+  }
+});
+
+test("It should update a few games with gaps", (t) => {
+  let count = 0;
+
+  const watcher = new Watcher({
+    scores,
+    year,
+    sport,
+    onSave(master) {
+      if (count === 0) {
+        t.equal(master, constants.EMPTY.replace("MWXX", "MW1X"));
+      } else if (count === 1) {
+        t.equal(master, constants.EMPTY.replace("MWXX", "MW18"));
+      }
+    },
+    onDrain() {
+      count++;
+      if (count === 2) t.end();
+    },
+  }).scores;
+
+  watcher.emit("event", {
+    region: "MW",
+    home: {
+      rank: 1,
+      winner: true,
+    },
+    away: {
+      rank: 16,
+      winner: false,
+    },
+  });
+
+  setTimeout(() => {
+    watcher.emit("event", {
+      region: "midwest",
+      home: {
+        rank: 8,
+        winner: true,
+      },
+      away: {
+        rank: 9,
+        winner: false,
+      },
+    });
+  }, 500);
+});

--- a/watchers/scores.js
+++ b/watchers/scores.js
@@ -2,8 +2,8 @@
 
 require("dotenv").config();
 
-const ScoreWatcher = require("@lukekarrys/score-watcher");
 const config = require("getconfig");
+const ScoreWatcher = require("./score-watcher");
 
 const initialBracket = require("../lib/initialBracket");
 const saveMaster = require("../lib/saveMaster");


### PR DESCRIPTION
[`@lukekarrys/entry-watcher`](https://npmjs.org/package/@lukekarrys/entry-watcher), [`@lukekarrys/score-watcher`](https://npmjs.org/package/@lukekarrys/score-watcher), and [`bracket-finder`](https://npmjs.org/package/bracket-finder) were only being used by this repo. Those packages have been deprecated and moved to this repo now. There is the ability to refactor some of this code now that it all lives in a single repo, but that will be left as an exercise to future me. For now this works.